### PR TITLE
Fix excludeFields on SelectorBuilder

### DIFF
--- a/lib/src/selector_builder.dart
+++ b/lib/src/selector_builder.dart
@@ -187,7 +187,7 @@ class SelectorBuilder{
     }
     paramFields = {};
     for (var field in fields) {
-      paramFields[field] = -1;
+      paramFields[field] = 0;
     }
     return this;
   }


### PR DESCRIPTION
In Selector class, excludeFields should use 0 as a value instead of -1.
http://docs.mongodb.org/manual/reference/method/db.collection.find/
