### PR TITLE
Added missing operators to ModifierBuilder

### DIFF
--- a/lib/src/modifier_builder.dart
+++ b/lib/src/modifier_builder.dart
@@ -4,41 +4,93 @@ part of mongo_dart_query;
 ModifierBuilder get modify => new ModifierBuilder();
 
 class ModifierBuilder{
+  
   Map map = {};
 
-  toString()=>"ModifierBuilder($map)";
+  toString() => "ModifierBuilder($map)";
+  
   Map _pair2Map(String fieldName, value) {
     var res = {};
     res[fieldName] = value;
     return res;
   }
-  ModifierBuilder inc(String fieldName,value) {
-    map['\$inc'] = _pair2Map(fieldName,value);
+  
+  void _updateOperation(String operator, String fieldName, value) {
+    Map opMap = map[operator];
+    if (opMap == null) {
+      opMap = {};
+      map[operator] = opMap;
+    }
+    opMap[fieldName] = value;
+  }
+  
+  ModifierBuilder inc(String fieldName, value) {
+    _updateOperation('\$inc', fieldName, value);
+    return this;
+  }
+  
+  ModifierBuilder min(String fieldName, value) {
+    _updateOperation('\$min', fieldName, value);
+    return this;
+  }
+  
+  ModifierBuilder max(String fieldName, value) {
+    _updateOperation('\$max', fieldName, value);
+    return this;
+  }
+  
+  ModifierBuilder rename(String oldName, String newName) {
+    _updateOperation('\$rename', oldName, newName);
     return this;
   }
 
-  ModifierBuilder set(String fieldName,value) {
-    Map setMap = map['\$set'];
-    if (setMap == null) {
-      setMap = {};
-    }
-    setMap[fieldName] = value;
-    map['\$set'] = setMap;
+  ModifierBuilder set(String fieldName, value) {
+    _updateOperation('\$set', fieldName, value);
+    return this;
+  }
+  
+  ModifierBuilder setOnInsert(String fieldName, value) {
+    _updateOperation('\$setOnInsert', fieldName, value);
     return this;
   }
 
   ModifierBuilder unset(String fieldName) {
-    Map unSetMap = map['\$unset'];
-    if (unSetMap == null) {
-      unSetMap = {};
-    }
-    unSetMap[fieldName] = 1;
-    map['\$unset'] = unSetMap;
+    _updateOperation('\$unset', fieldName, 1);
     return this;
   }
 
   ModifierBuilder push(String fieldName, value) {
-    map['\$push'] = _pair2Map(fieldName, value);
+    _updateOperation('\$push', fieldName,value);
+    return this;
+  }
+  
+  ModifierBuilder pushAll(String fieldName, List values) {
+    _updateOperation('\$pushAll', fieldName, values);
+    return this;
+  }
+  
+  ModifierBuilder pull(String fieldName, value) {
+    _updateOperation('\$pull', fieldName,value);
+    return this;
+  }
+  
+  ModifierBuilder pullAll(String fieldName, List values) {
+    _updateOperation('\$pullAll', fieldName, values);
+    return this;
+  }
+  
+  ModifierBuilder addToSet(String fieldName, value) {
+    _updateOperation('\$addToSet', fieldName,value);
+    return this;
+  }
+  
+  ModifierBuilder popFirst(String fieldName) {
+    _updateOperation('\$pop', fieldName, -1);
+    return this;
+  }
+  
+  ModifierBuilder popLast(String fieldName) {
+    _updateOperation('\$pop', fieldName, 1);
     return this;
   }
 


### PR DESCRIPTION
This PR just add some missing operators to ModifierBuilder, such as pull, pop, rename, min and max. Also, it fixes the behavior of inc and push operators, when applied to multiple fields. 
